### PR TITLE
Fixed tcp socket: using close() instead of shutdown()

### DIFF
--- a/src/tcp_socket.cpp
+++ b/src/tcp_socket.cpp
@@ -90,7 +90,7 @@ void TCPSocket::close()
   if (state_ != SocketState::Connected)
     return;
   state_ = SocketState::Closed;
-  ::shutdown(socket_fd_, SHUT_RDWR);
+  ::close(socket_fd_);
   socket_fd_ = -1;
 }
 


### PR DESCRIPTION
Fixed tcp socket: shutdown() does not destroy socket descriptor -> use close()

Otherwise, operating system holds descriptor for each executed trajectory -> runs out of open socket/file descriptors -> leads to error "accept() failed: Too many open files"