### PR TITLE
Bugfix: avoid socket_read timeouts in receiving thread

### DIFF
--- a/src/ros/lowbandwidth_trajectory_follower.cpp
+++ b/src/ros/lowbandwidth_trajectory_follower.cpp
@@ -193,34 +193,44 @@ def driveRobotLowBandwidthTrajectory():
             l_sent_waypoints_number = l_sent_waypoints_number + 1
         end
         join controlling_thread
+        send_message(-1)
     end
 
     thread receivingThread():
         local sending_thread = run sendingThread()
-        while True:
-            waypoint_received = socket_read_ascii_float(14, CONNECTION_NAME)
-            if waypoint_received[0] == 0:
-                textmsg("Not received trajectory for the last 2 seconds. Quitting")
-                enter_critical
-                g_stopping = True
-                exit_critical
-                break
-            elif waypoint_received[0] != JOINT_NUM * 2 + 2:
-                textmsg("Received wrong number of floats in trajectory. This is certainly not OK.")
-                textmsg(waypoint_received[0])
-                enter_critical
-                g_stopping = True
-                exit_critical
-                break
-            elif is_waypoint_sentinel(waypoint_received):
-                add_next_waypoint(waypoint_received)
-                enter_critical
-                g_stopping = True
-                g_received_waypoints_number = g_received_waypoints_number + 1
-                exit_critical
-                break
+        local l_stopping = False
+        local l_requested_waypoints_number = -1
+        local l_received_waypoints_number = -1
+        while not l_stopping:
+            enter_critical
+            l_requested_waypoints_number = g_requested_waypoints_number
+            l_received_waypoints_number = g_received_waypoints_number
+            l_stopping = g_stopping
+            exit_critical
+            if l_requested_waypoints_number > l_received_waypoints_number and not l_stopping:
+                waypoint_received = socket_read_ascii_float(14, CONNECTION_NAME)
+                if waypoint_received[0] == 0:
+                    textmsg("Not received trajectory point for the last 2 seconds. Quitting...")
+                    enter_critical
+                    g_stopping = True
+                    exit_critical
+                elif waypoint_received[0] != JOINT_NUM * 2 + 2:
+                    textmsg("Received wrong number of floats in trajectory. This is certainly not OK.")
+                    textmsg(waypoint_received[0])
+                    enter_critical
+                    g_stopping = True
+                    exit_critical
+                elif is_waypoint_sentinel(waypoint_received):
+                    add_next_waypoint(waypoint_received)
+                    enter_critical
+                    g_stopping = True
+                    g_received_waypoints_number = g_received_waypoints_number + 1
+                    exit_critical
+                else:
+                    add_next_waypoint(waypoint_received)
+                end
             end
-            add_next_waypoint(waypoint_received)
+            sync()
         end
         join sending_thread
     end
@@ -359,6 +369,11 @@ bool LowBandwidthTrajectoryFollower::execute(std::vector<TrajectoryPoint> &traje
         break;
      }
      unsigned int message_num=atoi((const char *) line);
+     if (message_num == -1) {
+         LOG_DEBUG("Received success message");
+         res = true;
+         break;
+     }
      LOG_DEBUG("Received request %i", message_num);
      if (message_num < trajectory.size())
      {

--- a/src/ros/lowbandwidth_trajectory_follower.cpp
+++ b/src/ros/lowbandwidth_trajectory_follower.cpp
@@ -368,14 +368,14 @@ bool LowBandwidthTrajectoryFollower::execute(std::vector<TrajectoryPoint> &traje
         finished = true;
         break;
      }
-     unsigned int message_num=atoi((const char *) line);
+     int message_num = atoi((const char *) line);
      if (message_num == -1) {
          LOG_DEBUG("Received success message");
          res = true;
          break;
      }
      LOG_DEBUG("Received request %i", message_num);
-     if (message_num < trajectory.size())
+     if (message_num < static_cast<int>(trajectory.size()))
      {
         res = execute(trajectory[message_num].positions, trajectory[message_num].velocities,
                 message_num, trajectory[message_num].time_from_start.count() / 1e6);

--- a/src/tcp_socket.cpp
+++ b/src/tcp_socket.cpp
@@ -90,7 +90,7 @@ void TCPSocket::close()
   if (state_ != SocketState::Connected)
     return;
   state_ = SocketState::Closed;
-  ::shutdown(socket_fd_, SHUT_RDWR);
+  ::close(socket_fd_);
   socket_fd_ = -1;
 }
 


### PR DESCRIPTION
- Issue: running trajectories with waypoints which have large time offsets (>2s, e.g. t0=0.0 and t1=5.0) caused the URScript to abort because the socket_read times out after 2s
- Solution: socket_read is only called when sending thread requested another waypoint

This especially lead to an abort if two distant waypoints are in the middle of the trajectory and time estimation results in a long duration for this "step" (e.g. by choosing low velocities). In this case the next waypoint is requested not until the current waypoint is reached -> socket only waits 2 seconds max and subsequently aborts the UR program.